### PR TITLE
Disable healing autocast on enemy units

### DIFF
--- a/scripts/spells.lua
+++ b/scripts/spells.lua
@@ -176,7 +176,7 @@ DefineSpell("spell-healing",
 	},
 	"sound-when-cast", "healing",
 	"depend-upgrade", "upgrade-healing",
-	"autocast", {"range", 6, "condition", {"HitPoints", {MaxValuePercent = 90}}},
+	"autocast", {"range", 6, "condition", {"alliance", "only", "HitPoints", {MaxValuePercent = 90}}},
 	"ai-cast", {"range", 6, "condition", {"alliance", "only", "HitPoints", {MaxValuePercent = 90}}}
 )
 


### PR DESCRIPTION
With auto cast enabled priests are healing enemy units too. Orcs don't appreciate their altruistic behavior and this does more harm than good usually.