### PR TITLE
more accurate damage calulation for the unit stat

### DIFF
--- a/scripts/ui.lua
+++ b/scripts/ui.lua
@@ -39,8 +39,8 @@ local info_panel_x = 2
 local info_panel_y = 70
 local info_panel_w = 64
 
-local min_damage = Div(ActiveUnitVar("PiercingDamage"), 2)
-local max_damage = Add(ActiveUnitVar("PiercingDamage"), ActiveUnitVar("BasicDamage"))
+local min_damage = Add(Div(ActiveUnitVar("PiercingDamage"),2), Add(Div(ActiveUnitVar("BasicDamage"), 2),1))
+local max_damage = Add(ActiveUnitVar("PiercingDamage"), Max(ActiveUnitVar("BasicDamage"), 1))
 local function ttlpercent()
    local ttlp = GetUnitVariable(-1, "TTLPercent")
    if ttlp > 0 then


### PR DESCRIPTION
this forumla is not perfect

the min damage is too low by 1 point in some cases 

i forgot exactly, i think it is if you attacking with piercing and base damage unit, then lowest damage (minimum) should be 1 higher. Anyway its much closer to the real game than the current one.