### PR TITLE
fix speed upgrade knights, fix wizards CTD summon

### DIFF
--- a/scripts/balancing.lua
+++ b/scripts/balancing.lua
@@ -83,14 +83,34 @@ DefineUnitType("unit-grunt", {
 -----------------------------------------------------------------------
 
 DefineUnitType("unit-knight", {
-                  Costs = {"time", 90, "gold", 850},
-                  Demand = 2,
-                  Armor = 1
+Costs = {"time", 90, "gold", 850},
+Demand = 2,
+Armor = 1
 })
 DefineUnitType("unit-raider", {
-                  Costs = {"time", 90, "gold", 850},
-                  Demand = 2,
-                  Armor = 1
+Costs = {"time", 90, "gold", 850},
+Demand = 2,
+Armor = 1
+})
+DefineUnitType("unit-knight1", {
+Costs = {"time", 90, "gold", 850},
+Demand = 2,
+Armor = 1
+})
+DefineUnitType("unit-raider1", {
+Costs = {"time", 90, "gold", 850},
+Demand = 2,
+Armor = 1
+})
+DefineUnitType("unit-knight2", {
+Costs = {"time", 90, "gold", 850},
+Demand = 2,
+Armor = 1
+})
+DefineUnitType("unit-raider2", {
+Costs = {"time", 90, "gold", 850},
+Demand = 2,
+Armor = 1
 })
 
 -----------------------------------------------------------------------
@@ -130,7 +150,7 @@ DefineUnitType("unit-water-elemental",{OnDeath = function(elemental, x, y)
       table.remove(CasterToElementalMap, caster)
       table.remove(ElementalToCasterMap, elemental)
       TransformUnit(caster, "unit-conjurer")
-      SetUnitVariable(caster, "Mana", 0)
+     -- SetUnitVariable(caster, "Mana", 0)
    end
 end})
 
@@ -192,7 +212,7 @@ DefineButton({ Pos = 5, Level = 0, Icon = "icon-cancel",
         table.remove(ElementalToCasterMap, elemental)
         RemoveUnit(elemental)
         TransformUnit(caster, "unit-conjurer")
-        SetUnitVariable(caster, "Mana", 0)
+       -- SetUnitVariable(caster, "Mana", 0)
      end
 end})
 
@@ -220,7 +240,7 @@ DefineUnitType("unit-daemon",{OnDeath = function(daemon, x, y)
       table.remove(CasterToDaemonMap, caster)
       table.remove(DaemonToCasterMap, daemon)
       TransformUnit(caster, "unit-warlock")
-      SetUnitVariable(caster, "Mana", 0)
+     -- SetUnitVariable(caster, "Mana", 0)
    end
 end})
 
@@ -283,6 +303,6 @@ DefineButton({ Pos = 5, Level = 0, Icon = "icon-cancel",
         table.remove(DaemonToCasterMap, daemon)
         RemoveUnit(daemon)
         TransformUnit(caster, "unit-warlock")
-        SetUnitVariable(caster, "Mana", 0)
+      --  SetUnitVariable(caster, "Mana", 0)
      end
 end})


### PR DESCRIPTION
add knight and rider stats  after speed upgrade

with disabled
SetUnitVariable(caster, "Mana", 0)

warclock and conjurer are working properly and are not CTD when the Elemental or Deamon are killed (when they are wizard stay in meditation state, and when you click cancel game CTD).


P.S.
your balancing changes are brilliant, and make Warcraft1 a much better game. im not sure why bother keeping the vanilla values? so player can experience how awfully OP were catapults or demons spam?