### PR TITLE
position of yellow key shortcut on icons

### DIFF
--- a/scripts/widgets.lua
+++ b/scripts/widgets.lua
@@ -120,7 +120,7 @@ DefineButtonStyle("icon", {
   TextNormalColor = "yellow",
   TextReverseColor = "white",
   TextAlign = "Right",
-  TextPos = {27, 13},
+  TextPos = {27, 12},
   Default = {
     Border = {
       Color = {0, 0, 0}, Size = 1,


### PR DESCRIPTION
yellow command letter hint on buttons is placed to low, cutting bottom part of letters
check here:
https://i.imgur.com/VBtNfJy.png