### PR TITLE
faster game and smoother animations

### DIFF
--- a/scripts/anim.lua
+++ b/scripts/anim.lua
@@ -214,9 +214,9 @@ end
 
 local function BuildAnimations(frames, ...)
    options = select(1, ...) or {}
-   speed = options.speed or 6
-   attackspeed = options.attackspeed or 5
-   coolofftime = options.coolofftime or 1
+   speed = options.speed or 4
+   attackspeed = options.attackspeed or 7
+   coolofftime = options.coolofftime or 20
    attacksound = options.attacksound or "sword attack"
    local returnvalue = {
       Still = options.Still or DefaultStillAnimation(),
@@ -252,13 +252,13 @@ DefineAnimations("animations-brigand", BuildAnimations(frameNumbers_5_5_3_2))
 
 DefineAnimations("animations-spider",
 		 BuildAnimations(frameNumbers_5_5_4_5,
-				 {attacksound = "fist attack", speed = 4}))
+				 {attacksound = "fist attack", speed = 3.5}))
 
 DefineAnimations("animations-water-elemental",
 		 BuildAnimations(frameNumbers_5_3_5_3,
-				 {speed = 4,
+				 {speed = 3.5,
 				  attacksound = "fireball attack",
-				  coolofftime = 24,
+				  coolofftime = 70,
 				  Still = {
 				      "frame 1", "wait 8",
 					  "frame 5", "wait 8",
@@ -267,9 +267,9 @@ DefineAnimations("animations-water-elemental",
 
 DefineAnimations("animations-fire-elemental",
 		 BuildAnimations(GetFrameNumbers(5, {5, 5, 0}),
-				 {speed = 5,
+				 {speed = 3.5,
 				  attacksound = "fireball attack",
-				  coolofftime = 24,
+				  coolofftime = 60,
 				  Still = {
 					  "frame 5", "wait 8",
 					  "frame 15", "wait 8",
@@ -293,7 +293,7 @@ DefineAnimations(
       attacksound = "fist attack",
       attackspeed = 15,
 	  coolofftime = 5,
-      speed = 8})
+      speed = 6})
 )
 
 local grizelda_garona_anim = {
@@ -318,7 +318,7 @@ DefineAnimations("animations-peon", worker_anim)
 
 local catapult_anim = BuildAnimations(
    frameNumbers_5_2_5_3,
-   { speed = 10,
+   { speed = 6,
      attackspeed = 25,
      coolofftime = 49,
      attacksound = "catapult attack" }
@@ -336,36 +336,36 @@ local anim_rider2 = BuildAnimations(frameNumbers_5_5_5_5, {speed = 2.7})
 DefineAnimations("animations-knight2", anim_rider2)
 DefineAnimations("animations-raider2", anim_rider2)
 
-DefineAnimations("animations-daemon", BuildAnimations(frameNumbers_5_5_5_5, {coolofftime = 24}))
+DefineAnimations("animations-daemon", BuildAnimations(frameNumbers_5_5_5_5, {coolofftime = 50}))
 DefineAnimations("animations-ogre",
 		 BuildAnimations(frameNumbers_5_5_5_5,
 				 {attacksound = "fist attack"}))
 DefineAnimations("animations-skeleton", BuildAnimations(frameNumbers_5_5_5_5))
 DefineAnimations("animations-scorpion",
 		 BuildAnimations(frameNumbers_5_5_5_5,
-				 {attacksound = "fist attack", speed = 4}))
+				 {attacksound = "fist attack", speed = 3.5}))
 DefineAnimations("animations-the-dead", BuildAnimations(frameNumbers_5_5_5_5))
 
 DefineAnimations("animations-archer",
 		 BuildAnimations(frameNumbers_5_5_2_3,
-				 {attackspeed = 10,
+				 {attackspeed = 14,
 				  attacksound = "arrow attack"}))
 DefineAnimations("animations-spearman",
 		 BuildAnimations(frameNumbers_5_5_2_3,
-				 {attackspeed = 10,
+				 {attackspeed = 13,
 				  attacksound = "arrow attack"}))
 
 DefineAnimations("animations-cleric",
 		 BuildAnimations(frameNumbers_5_5_4_3,
-				 {attacksound = "fireball attack", speed = 7}))
+				 {attacksound = "fireball attack", speed = 5}))
 
 DefineAnimations("animations-necrolyte",
 		 BuildAnimations(frameNumbers_5_5_5_4,
-				 {attacksound = "fireball attack", speed = 7}))
+				 {attacksound = "fireball attack", speed = 5}))
 
 DefineAnimations("animations-conjurer",
 		 BuildAnimations(frameNumbers_5_5_4_4,
-				 {attacksound = "fireball attack", speed = 7,
+				 {attacksound = "fireball attack", speed = 5,
 				  SpellCast = {
 				  "frame 5", "wait 8",
 				  "frame 20", "wait 8",
@@ -374,7 +374,7 @@ DefineAnimations("animations-conjurer",
 				  }}))
 DefineAnimations("animations-warlock",
 		 BuildAnimations(frameNumbers_5_5_5_3,
-				 {attacksound = "fireball attack", speed = 7,
+				 {attacksound = "fireball attack", speed = 5,
 				  SpellCast = {
 				  "frame 5", "wait 8",
 				  "frame 20", "wait 8",


### PR DESCRIPTION
increase move speed from 6 to 4 - this make whole warcraft1 playing experience much better, unit stop moving so slow ( at default speed 75 fastest)

decrease attack speed from 5 to 7
cooldown from 1 to 20 (yes, twenty) - player have a chance to take a part in combat and issue some orders, before all unit kill each other.

archers attack speed slow down from 10 to 14 (13 for spearman so he has extra edge over 1 shorter attack range)

casters move with speed 5. They are 1 speed point slower. This emulate the original w1 intention (because they old, and skip gym).

catapult move speed 6. Its still slower, than normal troops, but they dont drag behind, and animation looks smooth.

also slow down monsters and summons attacks. I test them in game, it balances a little overpower of Deamons and water elemental, but not that much to change meta.

-------------------------------------------------

i play w1 on various speed setting. Propose value are my defaults, I am changing other unit stats every game, but the speed setting are fine, and i didn't change them for a week. Unfortunately, i cannot include anim speeds in balancing lua, but i think there is no point trying to preserve old sluggish gameplay (reduce the speed in menu to achieve this feeling).

move speed of 4 i find the best. On speed 3.5 the normal foot unit is moving a bit too fast.

cavalry units are keeping their 3.7, 3.2 and 2.7 value. 
without upgrade, knights are similar fast as foot soldiers. And with each of the upgrades there is significant change of riders speed, that player see, and make breeding upgrades valuable.

Vanilla attack speeds are too fast. The combat end too fast, and player dont have a time to respond. Trying to escape from combat is pointless mostly, because this would end with receiving lots of damage without retaliation. 
thus all the attacks are slow down. but all the animation still looks fine. There is no feeling that the soldier stare at each other doing nothing.