### PR TITLE
slower mana reg, longer unholy armor

### DIFF
--- a/scripts/spells.lua
+++ b/scripts/spells.lua
@@ -31,7 +31,7 @@
 -- For documentation see stratagus/doc/ccl/ccl.html
 
 DefineBoolFlags("isundead", "organic", "hero", "volatile")
-DefineVariables("Mana", {Max = 0, Value = 64, Increase = 1, Enable = false}, "Speed", "ShadowFly", {Max = 2}, "Level")
+DefineVariables("Mana", {Max = 0, Value = 64, Increase = 1, IncreaseFrequency = 2, Enable = false}, "Speed", "ShadowFly", {Max = 2}, "Level")
 
 --  Declare some unit types used in spells. This is quite accetable, the other
 --  way would be to define can-cast-spell outside unit definitions, not much of an improvement.
@@ -81,8 +81,8 @@ local function SpellUnholyArmor(spell, unit, x, y, target)
 			DamageUnit(-1, target, 99999)
 		else
 			DamageUnit(-1, target, math.max(1, math.floor(GetUnitVariable(target, "HitPoints", "Max") / 2)))
-			SetUnitVariable(target, "UnholyArmor", 500, "Max")
-			SetUnitVariable(target, "UnholyArmor", 500, "Value")
+			SetUnitVariable(target, "UnholyArmor", 1000, "Max")
+			SetUnitVariable(target, "UnholyArmor", 1000, "Value")
 			SetUnitVariable(target, "UnholyArmor", 1, "Enable")
 		end
 	end
@@ -140,7 +140,7 @@ DefineSpell("spell-far-seeing",
 	"manacost", 70,
 	"range", "infinite",
 	"target", "position",
-	"action", {{"summon", "unit-type", "unit-revealer", "time-to-live", 100},
+	"action", {{"summon", "unit-type", "unit-revealer", "time-to-live", 1000},
 		{"spawn-missile", "missile", "missile-normal-spell",
 			"start-point", {"base", "target"}}},
 	"sound-when-cast", "vision",
@@ -152,7 +152,7 @@ DefineSpell("spell-dark-vision",
 	"manacost", 70,
 	"range", "infinite",
 	"target", "position",
-	"action", {{"summon", "unit-type", "unit-revealer", "time-to-live", 100},
+	"action", {{"summon", "unit-type", "unit-revealer", "time-to-live", 1000},
 		{"spawn-missile", "missile", "missile-normal-spell",
 			"start-point", {"base", "target"}}},
 	"sound-when-cast", "vision",


### PR DESCRIPTION
2x slower mana regeneration. 1/3 value is a little too harsh, and render the game a little less fun (i didnt check increase =2, increase freq =3 - maybe it would be the sweet spot).

unholy armor last twice as long (1000). with value 500 it ends way too short. Especially for demanding 60 mana, reducing HP to half, and research costing 3k gold. Necrolyte often cast it on non combat unit, basically damaging own troops.

invisibility (no change) has 2x use: you can cast it on own unit to save it from dying in combat, or you can cast it on a group of units to sneak them into enemy base. However I never manage to receive any good result with sneaking into opponents base. I even try to cast it on bunch of catapults, but enemy kill off my squad before i destroy even 1 building. 

vision spell last 10x. so when you play with fog of war, it has additional use as a spotter for your catapult assault. Still vision is too mana expensive, and in combat its a waste of mana, however when cleric sitting in your base doing nothing, then little peek what your enemy is doing is nice.