### PR TITLE
balancing units costs/times proposition

### DIFF
--- a/scripts/balancing.lua
+++ b/scripts/balancing.lua
@@ -6,56 +6,110 @@
 -- Sightrange Rebalancing Buildings
 -----------------------------------------------------------------------
 
-DefineUnitType("unit-human-farm", {SightRange = 5})
-DefineUnitType("unit-orc-farm", {SightRange = 5})
-DefineUnitType("unit-human-town-hall", {SightRange = 5})
-DefineUnitType("unit-orc-town-hall", {SightRange = 5})
-DefineUnitType("unit-human-barracks", {SightRange = 5})
-DefineUnitType("unit-orc-barracks", {SightRange = 5})
-DefineUnitType("unit-human-lumber-mill", {SightRange = 5})
-DefineUnitType("unit-orc-lumber-mill", {SightRange = 5})
-DefineUnitType("unit-stable", {SightRange = 5})
-DefineUnitType("unit-kennel", {SightRange = 5})
-DefineUnitType("unit-human-blacksmith", {SightRange = 5})
-DefineUnitType("unit-orc-blacksmith", {SightRange = 5})
-DefineUnitType("unit-church", {SightRange = 5})
-DefineUnitType("unit-temple", {SightRange = 5})
-DefineUnitType("unit-human-tower", {SightRange = 5})
-DefineUnitType("unit-orc-tower", {SightRange = 5})
-DefineUnitType("unit-stormwind-keep", {SightRange = 5})
-DefineUnitType("unit-blackrock-spire", {SightRange = 5})
+DefineUnitType("unit-human-farm", 			  {SightRange = 5})
+DefineUnitType("unit-orc-farm", 			    {SightRange = 5})
+DefineUnitType("unit-human-town-hall", 	  {SightRange = 5})
+DefineUnitType("unit-orc-town-hall", 		  {SightRange = 5})
+DefineUnitType("unit-human-barracks", 	  {SightRange = 5})
+DefineUnitType("unit-orc-barracks", 		  {SightRange = 5})
+DefineUnitType("unit-human-lumber-mill",	{SightRange = 5})
+DefineUnitType("unit-orc-lumber-mill", 		{SightRange = 5})
+DefineUnitType("unit-human-stable", 		  {SightRange = 5})
+DefineUnitType("unit-orc-kennel", 			  {SightRange = 5})
+DefineUnitType("unit-human-blacksmith", 	{SightRange = 5})
+DefineUnitType("unit-orc-blacksmith", 		{SightRange = 5})
+DefineUnitType("unit-human-church", 		  {SightRange = 5})
+DefineUnitType("unit-orc-temple", 			  {SightRange = 5})
+DefineUnitType("unit-human-tower", 			  {SightRange = 5})
+DefineUnitType("unit-orc-tower", 			    {SightRange = 5})
+DefineUnitType("unit-stormwind-keep", 		{SightRange = 5})
+DefineUnitType("unit-blackrock-spire", 		{SightRange = 5})
 
 -----------------------------------------------------------------------
 -- Sightrange Rebalancing Units
 -----------------------------------------------------------------------
 
-DefineUnitType("unit-peasant", {SightRange = 4})
-DefineUnitType("unit-peon", {SightRange = 4})
-DefineUnitType("unit-footman", {SightRange = 4})
-DefineUnitType("unit-grunt", {SightRange = 4})
-DefineUnitType("unit-archer", {SightRange = 6})
-DefineUnitType("unit-spearman", {SightRange = 6})
-DefineUnitType("unit-orc-catapult", {SightRange = 4})
+DefineUnitType("unit-peasant", 			  {SightRange = 4})
+DefineUnitType("unit-peon", 			    {SightRange = 4})
+DefineUnitType("unit-footman", 		  	{SightRange = 4})
+DefineUnitType("unit-grunt", 			    {SightRange = 4})
+DefineUnitType("unit-archer", 			  {SightRange = 6})
+DefineUnitType("unit-spearman", 		  {SightRange = 6})
+DefineUnitType("unit-orc-catapult", 	{SightRange = 4})
 DefineUnitType("unit-human-catapult", {SightRange = 4})
-DefineUnitType("unit-conjurer", {SightRange = 4})
-DefineUnitType("unit-warlock", {SightRange = 4})
-DefineUnitType("unit-cleric", {SightRange = 5})
-DefineUnitType("unit-necrolyte", {SightRange = 5})
+DefineUnitType("unit-raider", 			  {SightRange = 4})
+DefineUnitType("unit-knight", 			  {SightRange = 4})
+DefineUnitType("unit-raider1", 			  {SightRange = 4})
+DefineUnitType("unit-knight1", 			  {SightRange = 4})
+DefineUnitType("unit-raider2", 			  {SightRange = 4})
+DefineUnitType("unit-knight2", 			  {SightRange = 4})
+DefineUnitType("unit-conjurer", 		  {SightRange = 4})
+DefineUnitType("unit-warlock", 			  {SightRange = 4, MaxAttackRange = 3})
+DefineUnitType("unit-cleric", 			  {SightRange = 5, MaxAttackRange = 2})
+DefineUnitType("unit-necrolyte", 		  {SightRange = 5})
+
+-----------------------------------------------------------------------
+-- Cost Rebalancing Buildings
+-----------------------------------------------------------------------
+
+DefineUnitType("unit-human-farm",			    {Costs = {"time", 200, "gold", 500,		"wood", 300},})
+DefineUnitType("unit-orc-farm",			    	{Costs = {"time", 200, "gold", 500,		"wood", 300},})
+DefineUnitType("unit-human-barracks",		  {Costs = {"time", 300, "gold", 600, 	"wood", 500},})
+DefineUnitType("unit-orc-barracks",			  {Costs = {"time", 300, "gold", 600, 	"wood", 500},})
+DefineUnitType("unit-human-lumber-mill",	{Costs = {"time", 250, "gold", 600, 	"wood", 150},})
+DefineUnitType("unit-orc-lumber-mill",		{Costs = {"time", 250, "gold", 600, 	"wood", 150},})
+
+DefineUnitType("unit-human-stable",		  	{Costs = {"time", 300, "gold", 1000,	"wood", 400},})
+DefineUnitType("unit-orc-kennel",			    {Costs = {"time", 300, "gold", 1000, 	"wood", 400},})
+DefineUnitType("unit-human-blacksmith",		{Costs = {"time", 300, "gold", 900, 	"wood", 400},})
+DefineUnitType("unit-orc-blacksmith",		  {Costs = {"time", 300, "gold", 900, 	"wood", 400},})
+
+DefineUnitType("unit-human-church",		  	{Costs = {"time", 400, "gold", 800, 	"wood", 500},})
+DefineUnitType("unit-orc-temple",			    {Costs = {"time", 400, "gold", 800, 	"wood", 500},})
+DefineUnitType("unit-human-tower",		  	{Costs = {"time", 400, "gold", 1400, 	"wood", 300},})
+DefineUnitType("unit-orc-tower",			    {Costs = {"time", 400, "gold", 1400, 	"wood", 300},})
+
+DefineUnitType("unit-wall",					      {Costs = {"time", 30,  "gold", 0,		"wood", 50},})
+
+DefineUnitType("unit-gold-mine", 		    	{MaxOnBoard = 2})
+
+-----------------------------------------------------------------------
+-- Cost Rebalancing Units
+-----------------------------------------------------------------------
+
+DefineUnitType("unit-peasant", 				{Costs = {"time", 75,  "gold", 350, "wood", 0},})
+DefineUnitType("unit-peon", 				  {Costs = {"time", 75,  "gold", 350, "wood", 0},})
+DefineUnitType("unit-footman", 				{Costs = {"time", 150, "gold", 400, "wood", 0},})
+DefineUnitType("unit-grunt", 				  {Costs = {"time", 150, "gold", 400, "wood", 0},})
+DefineUnitType("unit-archer", 				{Costs = {"time", 200, "gold", 450, "wood", 50},})
+DefineUnitType("unit-spearman", 			{Costs = {"time", 200, "gold", 450, "wood", 50},})
+DefineUnitType("unit-orc-catapult", 	{Costs = {"time", 300, "gold", 650, "wood", 300},})
+DefineUnitType("unit-human-catapult", {Costs = {"time", 300, "gold", 650, "wood", 300},})
+
+DefineUnitType("unit-raider", 				{Costs = {"time", 250, "gold", 750, "wood", 100},}										  )
+DefineUnitType("unit-knight", 				{Costs = {"time", 250, "gold", 750, "wood", 100},})
+DefineUnitType("unit-raider1", 				{Costs = {"time", 250, "gold", 750, "wood", 100},})
+DefineUnitType("unit-knight1", 				{Costs = {"time", 250, "gold", 750, "wood", 100},})
+DefineUnitType("unit-raider2", 				{Costs = {"time", 250, "gold", 750, "wood", 100},})
+DefineUnitType("unit-knight2", 				{Costs = {"time", 250, "gold", 750, "wood", 100},})
+
+DefineUnitType("unit-cleric", 				{Costs = {"time", 300, "gold", 600, "wood", 50},})
+DefineUnitType("unit-necrolyte", 			{Costs = {"time", 300, "gold", 600, "wood", 50},})
+DefineUnitType("unit-conjurer", 			{Costs = {"time", 350, "gold", 800, "wood", 100},})
+DefineUnitType("unit-warlock", 				{Costs = {"time", 350, "gold", 800, "wood", 100},})
 
 -----------------------------------------------------------------------
 -- Catapult Rebalancing
 -----------------------------------------------------------------------
 
-DefineUnitType("unit-human-catapult", {
-                  Costs = {"time", 250, "gold", 900, "wood", 200},
-                  Demand = 4,
+DefineUnitType("unit-human-catapult", {                  
+                  Demand = 3,
                   BasicDamage = 150,
                   MaxAttackRange = 8,
                   MinAttackRange = 3,
 })
-DefineUnitType("unit-orc-catapult", {
-                  Costs = {"time", 250, "gold", 900, "wood", 200},
-                  Demand = 4,
+DefineUnitType("unit-orc-catapult", {                  
+                  Demand = 3,
                   BasicDamage = 150,
                   MaxAttackRange = 8,
                   MinAttackRange = 3,
@@ -83,32 +137,26 @@ DefineUnitType("unit-grunt", {
 -----------------------------------------------------------------------
 
 DefineUnitType("unit-knight", {
-                  Costs = {"time", 90, "gold", 850},
                   Demand = 2,
                   Armor = 1
 })
 DefineUnitType("unit-raider", {
-                  Costs = {"time", 90, "gold", 850},
                   Demand = 2,
                   Armor = 1
 })
 DefineUnitType("unit-knight1", {
-                  Costs = {"time", 90, "gold", 850},
                   Demand = 2,
                   Armor = 1
 })
 DefineUnitType("unit-raider1", {
-                  Costs = {"time", 90, "gold", 850},
                   Demand = 2,
                   Armor = 1
 })
 DefineUnitType("unit-knight2", {
-                  Costs = {"time", 90, "gold", 850},
                   Demand = 2,
                   Armor = 1
 })
 DefineUnitType("unit-raider2", {
-                  Costs = {"time", 90, "gold", 850},
                   Demand = 2,
                   Armor = 1
 })
@@ -306,3 +354,50 @@ DefineButton({ Pos = 5, Level = 0, Icon = "icon-cancel",
       --  SetUnitVariable(caster, "Mana", 0)
      end
 end})
+
+
+-----------------------------------------------------------------------
+-- Upgrades Rebalancing
+-----------------------------------------------------------------------
+
+local upgrades = {
+   {orc = {"axe1", {"grunt", "raider", "raider1", "raider2"}, "axe2"},
+    human = {"sword1", {"footman", "knight", "knight1", "knight2"}, "sword2"},
+    cost = {   1200,   750,     400,     0,     0,     0,     0},
+    },
+   {orc = {"axe2", {"grunt", "raider", "raider1", "raider2"}, "axe3"},
+    human = {"sword2", {"footman", "knight", "knight1", "knight2"}, "sword3"},
+    cost = {   1200,   1500,     800,     0,     0,     0,     0},
+    },
+
+   {orc = {"spear1", {"spearman"}, "spear2"},
+    human = {"arrow1", {"archer"}, "arrow2"},
+    cost = {   1400,   750,		400,     0,     0,     0,     0},
+    },
+   {orc = {"spear2", {"spearman"}, "spear3"},
+    human = {"arrow2", {"archer"}, "arrow3"},
+    cost = {   1400,   1500,     800,     0,     0,     0,     0},
+    },
+
+   {orc = {"orc-shield1", {"grunt", "raider", "raider1", "raider2"}, "orc-shield2"},
+    human = {"human-shield1", {"footman", "knight", "knight1", "knight2"}, "human-shield2"},
+    cost = {   1200,   750, 	400,     0,     0,     0,     0},
+   },  
+   {orc = {"orc-shield2", {"grunt", "raider", "raider1", "raider2"}, "orc-shield3"},
+    human = {"human-shield2", {"footman", "knight", "knight1", "knight2"}, "human-shield3"},
+    cost = {   1200,   1500,     800,     0,     0,     0,     0}, 
+    },
+
+   {orc = {"wolves1", {"raider"}},
+    human = {"horse1", {"knight"}},
+    cost = {   700,   750, 	400,     0,     0,     0,     0},
+    },
+   {orc = {"wolves2", {"raider1"}},
+    human = {"horse2", {"knight1"}},
+    cost = {   700,   1500,     800,     0,     0,     0,     0},
+   },	
+}
+
+for idx,spec in ipairs(upgrades) do
+   DefineUpgradeFromSpec(spec)
+end


### PR DESCRIPTION
below is my proposition after playing 2 weeks of war1gus on solo/campaign. I try to be modest with my suggestion, including the one that are straight beneficial, i have written below explanation for each.

Im not claiming that Im right with everything here, but i find game with this stats much more fun. I didnt test it on multi.

---------------------------
fix bug with some building (like stable kennel - without race prefix) not having increase sight range
fix rider/knight not having increase sight range

cleric with 1 range is odd. He has melee range, but his graphic showing projectile. Gameplay wise he is much more useful in combat having 2 range, otherwise he is easy pick and kill for enemy.
warlock - to compensate above for orcs, i increase to 3 warlock attack range so it mirror conjurer.

all buildings have 2x increase build time. Building time was too short. Now its considerable to use multiple workers to speed up critical construction. With slower construction there is more time to play early game. f.ex. time to Demons appearance is longer.

Lumber mill cost 150 wood. If you ever find yourself short of wood, you think "oh i could drop a Lumber mill close to this forest". Too bad you dont have 500 wood to do so. Which hinder whole your economy for a while. 
"but why 150 wood and not 0?" 
feel more sensible (you need wood to build anything). When you low on wood, you usually have some scraps of lumber.

wall cost wood not gold. make more sense, its a nice balance of town hall options. 100  gold for such flimsy palisade was a waste of money. when it cost wood, i sometimes go for it to spend surplus of timber resources.

gold mine allow only 2 miners inside not 5. 
vanilla allow extremely fast mining, a gold rush. with lower miners capacity, the path between mine and town hall gets faster saturated with workers. player can focus on something else than pumping workers. Also when one mine gets saturated with workers, its worth to send spare workers for travelling to distant mine, which open new strategical and tactical implication to the game (worker harassment).
"so why not 1 miner inside?"
this setting may be too harsh for many players, who will find it very odd, and will be reluctant to send workers away from base. With 2 miners inside gold mine, the gold income is still quite good to play without gold expeditions.

all units are produce much longer. You take into consideration to build another barrack, temple, church, tower - which i think is good, to give reason to build more structures.
the units are not getting replaced with fresh one so fast. So little tactical victories are more important - troops preservation.

units cost wood. Wood is an underused resource. If you need to have it for knights or spell caster, it becomes more attractive.

footman is even more useful unit. he train quickest and cost only gold. which make him a good choice in many situations.

casters train the longest, so going for double church or tower is sensible.

catapults need 3 supply, with 4 it means that you need farm for every catapult. besides they cost 300 wood now, which limit they production a lot.

upgrades need wood and are research 10x as long.
it was silly to build a blacksmith and in short time having all 4 upgrades. Now it take some time to have fully upgraded army. Which create a time windows to play with less upgraded troops.