### PR TITLE
default scroll speed increase

### DIFF
--- a/scripts/stratagus.lua
+++ b/scripts/stratagus.lua
@@ -160,18 +160,18 @@ SetKeyScroll(true)
 --SetKeyScroll(false)
 
 --  Set keyboard scroll speed in frames (1=each frame,2 each second,...)
---SetKeyScrollSpeed(1)
+SetKeyScrollSpeed(8)
 
 --  Set mouse scroll speed in pixels per frame
 --  This is when the mouse cursor hits the border.
---SetMouseScrollSpeed(1)
+SetMouseScrollSpeed(4)
 
 --  While middle-mouse is pressed:
 --  Pixels to move per scrolled mouse pixel, negative = reversed
-SetMouseScrollSpeedDefault(4)
+SetMouseScrollSpeedDefault(1)
 
 --  Same if Control is pressed
-SetMouseScrollSpeedControl(15)
+SetMouseScrollSpeedControl(2)
 
 --  Change next, for the wanted double-click delay (in ms).
 SetDoubleClickDelay(300)


### PR DESCRIPTION
map scroll with key and nudging mouse to edge is way too slow.
Ideally, "someone" should make an option in menu (slider). But for now i this setting is much more comfortable, for a newbie who dont want/cant/need to change anything.
-------

p.s.
SetMouseScrollSpeedControl(2)  - this is useless. i can achieve whatever speed i want with middle mouse by moving mouse further or closer.