### PR TITLE
increase worker time inside goldmine

### DIFF
--- a/scripts/units.lua
+++ b/scripts/units.lua
@@ -124,7 +124,7 @@ local units = {
     CanGatherResources = {
        {"resource-id", "gold",
         "resource-capacity", 100,
-        "wait-at-resource", 150,
+        "wait-at-resource", 300,
         "wait-at-depot", 150},
        {"resource-id", "wood",
         "resource-capacity", 100,


### PR DESCRIPTION
this reduces gold income speed in balanced game to much better values, which help reduce footman spam tactic, and promote tech up with constructing more structures with wood.

this doesn't affect vanilla game in a noticable way, player still is showered with gold, and can send 8 workers to single goldmine.

i cannot change it in balancing lua, without a sprite bug.