### PR TITLE
stop droping wood

### DIFF
--- a/scripts/units.lua
+++ b/scripts/units.lua
@@ -131,7 +131,7 @@ local units = {
         "resource-step", 2,
         "wait-at-resource", 24,
         "wait-at-depot", 150,
-        "lose-resources",
+        --"lose-resources",
         "terrain-harvester"},
        {"resource-id", "lumber", -- dungeon's harvest wood outside
         "resource-capacity", 100,


### PR DESCRIPTION
its an excellent feature of warcraft2 wargus. Honestly, no wood wasting was the main reason i play wargus. 

it releases a LOT of pressure from harvesting wood. I suddenly stop looking for a peon with the lowest amount of wood to send him to build farms.

and give me a break with the nostalgia. No one will notice its missing from the senile game. Losing lumber is a flaw in gameplay.

but why not only in balancing.lua? 
apparently the worker animation depend on the unit.lua, and worker is animated without a wood if I overwrite the wood gathering parapemetr.