### PR TITLE
spell-skill for spiders to slow down

### DIFF
--- a/scripts/spells.lua
+++ b/scripts/spells.lua
@@ -201,7 +201,7 @@ DefineSpell("spell-raise-dead",
 
 DefineSpell("spell-unholy-armor",
 	"showname", "unholyarmor",
-	"manacost", 50,
+	"manacost", 40,
 	"range", 8,
 	"target", "unit",
 	"action", {{"lua-callback", SpellUnholyArmor},
@@ -221,7 +221,7 @@ DefineSpell("spell-unholy-armor",
 
 DefineSpell("spell-invisibility",
 	"showname", "invisibility",
-	"manacost", 50,
+	"manacost", 40,
 	"range", 8,
 	"target", "unit",
 	"action", {{"adjust-variable", {Invisible = 2000}},
@@ -336,3 +336,19 @@ DefineSpell("spell-rain-of-fire",
 	"ai-cast", {"range", 12, "priority", {"Priority", true}, "condition", {"opponent", "only"}, "position-autocast", SpellBlizzard}
 )
 
+DefineSpell("spell-slow",
+	"showname", _("Slow"),
+	"manacost", 0,
+	"range", 10,
+	"target", "unit",
+	 "cooldown", 1000,
+	"action", {{"adjust-variable", {Slow = 500, Haste = 0}},
+		{"spawn-missile", "missile", "missile-web",
+			"start-point", {"base", "target"}}},
+	"condition", {
+		"Building", "false",
+		"Slow", {ExactValue = 0}},
+	"sound-when-cast", "raise dead", 
+	"autocast", {"range", 10, "condition", {"Coward", "false", "opponent", "only"}},
+	"ai-cast", {"range", 10, "combat", "only", "condition", {"Coward", "false", "opponent", "only"}}
+)


### PR DESCRIPTION
also reduce mana cost of UA and Invisibility

invisibility is super trash spell. I still cant see an aplication for it. I was using it to save units in combat, but if unit has attack order he will decloak herself immediately, increasing needed micro. If unit dont decloak after attack... well then its starcraft case of invisibility, and its like Unholy armor level. And maybe Catapults and Rain of Fire gain on importance.

unholy armor is great, but cutting half hp is a big draw back. When you can cast it on enemy is quite fun. Just 1x cast with one Necrolyte is not enough, and is very rare to have 100 mana.