### PR TITLE
idle workers counter

### DIFF
--- a/scripts/ui.lua
+++ b/scripts/ui.lua
@@ -364,6 +364,10 @@ UI.Resources[FoodCost].IconY = 0
 UI.Resources[FoodCost].TextX = Video.Width - 0 - 13 - 40
 UI.Resources[FoodCost].TextY = 1
 
+-- idle workers
+UI.Resources[FreeWorkersCount].TextX = Video.Width - 14
+UI.Resources[FreeWorkersCount].TextY = 1
+
 -- mana -- no good icon, but we need this for the info bar
 UI.Resources[ManaResCost].G = CGraphic:New("contrib/graphics/ui/mana_icon_1.png", 9,9)
 UI.Resources[ManaResCost].IconFrame = 0


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/93911529/153729580-2b77e2d2-2af2-4658-8ff5-ed3cf8ec3873.png)

just a little number after food icon.

i feel the top UI bar is getting too crowded, and thats sufficient information

(im just too stupid to make idle worker button :) )