### PR TITLE
unholy armor cost more mana to cast

### DIFF
--- a/scripts/spells.lua
+++ b/scripts/spells.lua
@@ -201,7 +201,7 @@ DefineSpell("spell-raise-dead",
 
 DefineSpell("spell-unholy-armor",
 	"showname", "unholyarmor",
-	"manacost", 40,
+	"manacost", 55,
 	"range", 8,
 	"target", "unit",
 	"action", {{"lua-callback", SpellUnholyArmor},


### PR DESCRIPTION
55mana, so necro can cast it only at one unit per time (double cast per necro is OP).