### PR TITLE
AI faster tech up, use towers

### DIFF
--- a/scripts/ai/land_attack.lua
+++ b/scripts/ai/land_attack.lua
@@ -169,9 +169,9 @@ function CreateAiLandAttack(sleep_factor, max_force)
 	  function() return AiNeed(AiLumberMill()) end,
 	  function() return AiWait(AiBarracks()) end,
       function() return AiForce(0, {AiSoldier(), 2}) end,
-      function() return AiForce(1, {AiSoldier(), 1}) end,
-      function() return AiWaitForce(1) end,
-      function() return AiAttackWithForce(1) end,
+      --function() return AiForce(1, {AiSoldier(), 1}) end,
+      --function() return AiWaitForce(1) end,
+      --function() return AiAttackWithForce(1) end,
       function() return AiSleep(1) end,      
 
       function () return GenerateRoads(true, false) end,
@@ -180,11 +180,13 @@ function CreateAiLandAttack(sleep_factor, max_force)
       function() return AiSleep(500) end,
       function() return AiNeed(AiBlacksmith()) end,
 	  function() return AiWait(AiWorker()) end,
-	  function() return AiWait(AiLumberMill()) end,
+	  function() return AiWait(AiLumberMill()) end, 
+      function() return AiNeed(AiTower()) end,
       function() return AiForce(0, {AiSoldier(), 2, AiShooter(), 1}) end,
       function() return AiForce(1, {AiSoldier(), 2, AiShooter(), 1}) end,
       function() return AiWaitForce(0) end,
       function() return AiWaitForce(1) end,
+	  function() return AiNeed(AiTower()) end,
       function() return AiSleep(500) end,
       function() return AiAttackWithForce(1) end,
 
@@ -194,9 +196,9 @@ function CreateAiLandAttack(sleep_factor, max_force)
       function() return AiResearch(AiUpgradeWeapon1()) end,
       function() return AiResearch(AiUpgradeArmor1()) end,
       function() return AiResearch(AiUpgradeMissile1()) end,
-      function() return AiResearch(AiUpgradeWeapon2()) end,
-      function() return AiResearch(AiUpgradeArmor2()) end,
-      function() return AiResearch(AiUpgradeMissile2()) end,
+      --function() return AiResearch(AiUpgradeWeapon2()) end,
+      --function() return AiResearch(AiUpgradeArmor2()) end,
+      --function() return AiResearch(AiUpgradeMissile2()) end,
       function() return AiNeed(AiBarracks()) end,
 	  function() return AiWait(AiBarracks()) end,
 
@@ -230,7 +232,7 @@ function CreateAiLandAttack(sleep_factor, max_force)
 
       function() return AiSleep(500) end,
       function() return AiNeed(AiStables()) end,
-      function() return AiForce(0, {AiSoldier(), 1, AiShooter(), 2, AiCavalry(), 6, AiCatapult(), 1}) end,
+      function() return AiForce(0, {AiSoldier(), 1, AiShooter(), 2, AiCavalry(), 3, AiCatapult(), 1}) end,
       function() return AiForce(1, {AiSoldier(), 1, AiShooter(), 2, AiCavalry(), 2, AiCatapult(), 1}) end,
       function() return AiWaitForce(0) end,
       function() return AiWaitForce(1) end,
@@ -240,7 +242,7 @@ function CreateAiLandAttack(sleep_factor, max_force)
       function() return AiNeed(AiBarracks()) end,
       function() return AiSet(AiWorker(), 19) end,
 
-      function() return AiForce(0, {AiSoldier(), 1, AiShooter(), 2, AiCavalry(), 6, AiCatapult(), 1}) end,
+      function() return AiForce(0, {AiSoldier(), 1, AiShooter(), 2, AiCavalry(), 3, AiCatapult(), 1}) end,
       function() return AiForce(1, {AiSoldier(), 1, AiShooter(), 2, AiCavalry(), 2, AiCatapult(), 1}) end,
       function() return AiWaitForce(0) end,
       function() return AiWaitForce(1) end,
@@ -255,7 +257,7 @@ function CreateAiLandAttack(sleep_factor, max_force)
 
       function () return GenerateRoads(true, true) end,
 
-      function() return AiForce(0, {AiSoldier(), 1, AiShooter(), 2, AiCavalry(), 4, AiMage(), 1, AiCatapult(), 1}) end,
+      function() return AiForce(0, {AiSoldier(), 1, AiShooter(), 2, AiCavalry(), 2, AiMage(), 1, AiCatapult(), 1}) end,
       function() return AiForce(1, {AiSoldier(), 1, AiShooter(), 2, AiCavalry(), 3, AiMage(), 1, AiCatapult(), 1}) end,
       function() return AiWaitForce(0) end,
       function() return AiWaitForce(1) end,
@@ -268,7 +270,7 @@ function CreateAiLandAttack(sleep_factor, max_force)
       function() return AiResearch(AiSummonerSpell1()) end,
       function() return AiResearch(AiSummonerSpell3()) end,
 
-      function() return AiForce(0, {AiSoldier(), 1, AiShooter(), 2, AiCavalry(), 6, AiCatapult(), 3, AiMage(), 2, AiSummoner(), 2}) end,
+      function() return AiForce(0, {AiSoldier(), 1, AiShooter(), 2, AiCavalry(), 3, AiCatapult(), 3, AiMage(), 2, AiSummoner(), 2}) end,
       function() return AiForce(1, {AiSoldier(), 1, AiShooter(), 2, AiCavalry(), 2, AiCatapult(), 1, AiMage(), 1, AiSummoner(), 1}) end,
       function() return AiWaitForce(0) end,
       function() return AiWaitForce(1) end,
@@ -279,7 +281,7 @@ function CreateAiLandAttack(sleep_factor, max_force)
 
       function () return GenerateRoads(true, true) end,
 
-      function() return AiForce(0, {AiSoldier(), 1, AiShooter(), 2, AiCavalry(), 6, AiCatapult(), 1, AiMage(), 2, AiSummoner(), 2}) end,
+      function() return AiForce(0, {AiSoldier(), 1, AiShooter(), 2, AiCavalry(), 3, AiCatapult(), 1, AiMage(), 2, AiSummoner(), 2}) end,
       function() return AiForce(1, {AiSoldier(), 1, AiShooter(), 2, AiCavalry(), 2, AiCatapult(), 1, AiMage(), 1, AiSummoner(), 1}) end,
       function() return AiWaitForce(0) end,
       function() return AiWaitForce(1) end,
@@ -289,7 +291,7 @@ function CreateAiLandAttack(sleep_factor, max_force)
 
       function() return AiSleep(500) end,
 
-      function() return AiForce(0, {AiSoldier(), 1, AiShooter(), 2, AiCavalry(), 6, AiCatapult(), 1, AiMage(), 2, AiSummoner(), 2}) end,
+      function() return AiForce(0, {AiSoldier(), 1, AiShooter(), 2, AiCavalry(), 3, AiCatapult(), 1, AiMage(), 2, AiSummoner(), 2}) end,
       function() return AiForce(1, {AiSoldier(), 1, AiShooter(), 2, AiCavalry(), 2, AiCatapult(), 1, AiMage(), 1, AiSummoner(), 1}) end,
       function() return AiWaitForce(0) end,
       function() return AiWaitForce(1) end,
@@ -299,7 +301,7 @@ function CreateAiLandAttack(sleep_factor, max_force)
 
       function () return GenerateRoads(true, true) end,
 
-      function() return AiForce(0, {AiSoldier(), 1, AiShooter(), 2, AiCavalry(), 6, AiCatapult(), 1, AiMage(), 2, AiSummoner(), 5}) end,
+      function() return AiForce(0, {AiSoldier(), 1, AiShooter(), 2, AiCavalry(), 3, AiCatapult(), 1, AiMage(), 2, AiSummoner(), 5}) end,
       function() return AiForce(1, {AiSoldier(), 1, AiShooter(), 2, AiCavalry(), 2, AiCatapult(), 1, AiMage(), 1, AiSummoner(), 1}) end,
       function() return AiWaitForce(0) end,
       function() return AiWaitForce(1) end,
@@ -307,7 +309,7 @@ function CreateAiLandAttack(sleep_factor, max_force)
       function() return AiAttackWithForce(1) end,
 
       function() return AiSleep(500) end,
-      function() return AiForce(0, {AiSoldier(), 1, AiShooter(), 2, AiCavalry(), 6, AiCatapult(), 1, AiMage(), 2, AiSummoner(), 5}) end,
+      function() return AiForce(0, {AiSoldier(), 1, AiShooter(), 2, AiCavalry(), 3, AiCatapult(), 1, AiMage(), 2, AiSummoner(), 5}) end,
       function() return AiForce(1, {AiSoldier(), 1, AiShooter(), 2, AiCavalry(), 2, AiCatapult(), 1, AiMage(), 1, AiSummoner(), 1}) end,
       function() return AiWaitForce(0) end,
       function() return AiWaitForce(1) end,


### PR DESCRIPTION
AI is trying to keep 2x defence towers in base, which is good.

i disable AI first attack with 1x footman, because its just a waste - it maybe serves a purpose as scouting, but AI see everything so why bother (to simulate game with human :-) ? )

i disable 2nd level of upgrades - they are very expensive - not sure if AI follow economy, but if so, this holds him back

i reduce the amount of Cavalry AI produce, so AI transit to spell casters faster, which make the game more diverse (and keeping 6 Knights in base "just in case" is an underperformance