### PR TITLE
longer wood gathering in dungeon

### DIFF
--- a/scripts/units.lua
+++ b/scripts/units.lua
@@ -146,7 +146,7 @@ local units = {
         "terrain-harvester"},
        {"resource-id", "lumber", -- dungeon's harvest wood outside
         "resource-capacity", 100,
-        "wait-at-resource", 150,
+        "wait-at-resource", 1200,
         "wait-at-depot", 150,
         "final-resource", "wood"},
        {"resource-id", "treasure", -- dungeon's have treasure chests to plunder


### PR DESCRIPTION
to chop down tree, worker need about 1200 time units - i check this 1200 in game  

otherwise (on dungeon map that we dont have yet too much), wood income is as fast as gold from gold mine

still wood income is great because 5x workers can exit the dungeon at once.