### PR TITLE
CI: cleanup macOS CI by using the bundle script

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,4 +1,4 @@
-name: macos-arm64
+name: macOS-arm64
 
 on:
   workflow_dispatch:
@@ -49,7 +49,8 @@ jobs:
 
     - name: Build Stratagus
       run: |
-        cmake stratagus -B stratagus/build \ -DCMAKE_BUILD_TYPE=Release \
+        cmake stratagus -B stratagus/build \
+        -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_VENDORED_LUA=ON \
         -DBUILD_VENDORED_SDL=OFF \
         -DBUILD_VENDORED_MEDIA_LIBS=OFF \
@@ -60,45 +61,23 @@ jobs:
       run: |
         cmake war1gus -B war1gus/build \
         -DSTRATAGUS_INCLUDE_DIR=../stratagus/gameheaders \
-        -DSTRATAGUS=../stratagus/build/stratagus 
+        -DSTRATAGUS=../stratagus/build/stratagus \
+        -DENABLE_VENDORED_LIBS=OFF
         cmake --build war1gus/build --config Release
 
     - name: Create War1gus app bundle
       run: |
-        rm -rf War1gus.app
-        mkdir -p War1gus.app/Contents/Resources
-        mkdir -p War1gus.app/Contents/MacOS
+        export STRATAGUS_INCLUDE_DIR=stratagus/gameheaders
+        export STRATAGUS=stratagus/build/stratagus
+        war1gus/mac/bundle.sh
         
-        cp war1gus/mac/Info.plist War1gus.app/Contents/
+        dylibbundler -of -cd -b -x war1gus/mac/War1gus.app/Contents/MacOS/stratagus -d war1gus/mac/War1gus.app/Contents/libs/
+        dylibbundler -of -cd -b -x war1gus/mac/War1gus.app/Contents/MacOS/war1tool -d war1gus/mac/War1gus.app/Contents/libs/
         
-        mkdir war1gus.iconset
-        sips -z 16 16     war1gus/war1gus.png --out war1gus.iconset/icon_16x16.png
-        sips -z 32 32     war1gus/war1gus.png --out war1gus.iconset/icon_16x16@2x.png
-        sips -z 32 32     war1gus/war1gus.png --out war1gus.iconset/icon_32x32.png
-        sips -z 64 64     war1gus/war1gus.png --out war1gus.iconset/icon_32x32@2x.png
-        sips -z 128 128   war1gus/war1gus.png --out war1gus.iconset/icon_128x128.png
-        sips -z 256 256   war1gus/war1gus.png --out war1gus.iconset/icon_128x128@2x.png
-        sips -z 256 256   war1gus/war1gus.png --out war1gus.iconset/icon_256x256.png
-        sips -z 512 512   war1gus/war1gus.png --out war1gus.iconset/icon_256x256@2x.png
-        sips -z 512 512   war1gus/war1gus.png --out war1gus.iconset/icon_512x512.png
-        sips -z 1024 1024   war1gus/war1gus.png --out war1gus.iconset/icon_512x512@2x.png
-        iconutil -c icns war1gus.iconset
-        rm -R war1gus.iconset
-        mv war1gus.icns War1gus.app/Contents/Resources/
-        
-        cp -R war1gus/shaders war1gus/campaigns war1gus/contrib war1gus/maps war1gus/scripts War1gus.app/Contents/MacOS/
-        
-        cp war1gus/build/war1tool War1gus.app/Contents/MacOS/
-        cp war1gus/build/war1gus War1gus.app/Contents/MacOS/
-        cp stratagus/build/stratagus War1gus.app/Contents/MacOS/stratagus
-        
-        dylibbundler -of -cd -b -x War1gus.app/Contents/MacOS/stratagus -d War1gus.app/Contents/libs/
-        dylibbundler -of -cd -b -x War1gus.app/Contents/MacOS/war1tool -d War1gus.app/Contents/libs/
-        
-        codesign --force --deep --sign - War1gus.app
+        codesign --force --deep --sign - war1gus/mac/War1gus.app
         
     - name: Create dmg
-      run: hdiutil create -volname "War1gus" -srcfolder "War1gus.app" "War1gus-arm64"
+      run: hdiutil create -volname "War1gus" -srcfolder "war1gus/mac/War1gus.app" "War1gus-arm64"
     
     - name: Upload artifacts - macOS arm64
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
Uses the bundle script located in `war1gus/Mac/bundle.sh` to create the basic bundle. 

This removes roughly 20 lines of duplicated code. 