### PR TITLE
Add CMake flag for preferring homebrew libs

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -51,6 +51,7 @@ jobs:
       run: |
         cmake stratagus -B stratagus/build \
         -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_FIND_FRAMEWORK=LAST \
         -DBUILD_VENDORED_LUA=ON \
         -DBUILD_VENDORED_SDL=OFF \
         -DBUILD_VENDORED_MEDIA_LIBS=OFF \
@@ -60,6 +61,7 @@ jobs:
     - name: Build War1gus
       run: |
         cmake war1gus -B war1gus/build \
+        -DCMAKE_FIND_FRAMEWORK=LAST \
         -DSTRATAGUS_INCLUDE_DIR=../stratagus/gameheaders \
         -DSTRATAGUS=../stratagus/build/stratagus \
         -DENABLE_VENDORED_LIBS=OFF


### PR DESCRIPTION
This allows CMake to build using latest libpng `1.6.47` instead of the old version. 

Fixes several war1tool conversion issues